### PR TITLE
CUDA error status を正しく記録する修正

### DIFF
--- a/modules/cuda_efficient_features/CMakeLists.txt
+++ b/modules/cuda_efficient_features/CMakeLists.txt
@@ -8,7 +8,7 @@ set(INTERNAL_INCLUDE_DIR ${INTERFACE_INCLUDE_DIR})
 project(${PROJECT_NAME} LANGUAGES CXX CUDA)
 
 # dependent packages
-find_package(OpenCV REQUIRED core features2d cudev cudafilters cudaimgproc cudawarping cudafeatures2d)
+find_package(OpenCV REQUIRED core features2d cudev cudaarithm cudafilters cudaimgproc cudawarping cudafeatures2d)
 find_package(CUDAToolkit REQUIRED)
 
 # target configuration

--- a/modules/cuda_efficient_features/include/cuda_efficient_features.h
+++ b/modules/cuda_efficient_features/include/cuda_efficient_features.h
@@ -86,6 +86,11 @@ public:
 	virtual void detectAndComputeAsync(InputArray image, InputArray mask, OutputArray keypoints, OutputArray descriptors,
 		bool useProvidedKeypoints = false, Stream& stream = Stream::Null()) = 0;
 
+	/** Detects keypoints and computes descriptors per channel for multi-channel input. */
+	virtual void detectAndComputeAsyncPerChannel(InputArray image, InputArray mask,
+		std::vector<GpuMat>& keypoints, std::vector<GpuMat>& descriptors,
+		bool useProvidedKeypoints = false, Stream& stream = Stream::Null()) = 0;
+
 	/** Converts keypoints array from internal representation to standard vector. */
 	virtual void convert(InputArray gpu_keypoints, std::vector<KeyPoint>& keypoints) = 0;
 

--- a/modules/cuda_efficient_features/src/bad.p512.md
+++ b/modules/cuda_efficient_features/src/bad.p512.md
@@ -1,0 +1,37 @@
+# bad.p512.h
+
+## 目的
+
+`bad.p512` は BAD descriptor 系の feature 計算を提供する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/bad.p512.h`
+- 判定条件: 394 行のため sidecar 文書を維持対象にする
+
+## 現状
+
+### 主な構成
+- file 内の処理量が大きいため、隣接 module との境界を追える補助資料として扱う
+
+### 連携境界
+- 同一 package 内の class / utility と連携して役割を分担する
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/bad.p512.h`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/bad.p512.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_akaze.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_efficient_features.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_hash_sift.md`

--- a/modules/cuda_efficient_features/src/cuda_akaze.md
+++ b/modules/cuda_efficient_features/src/cuda_akaze.md
@@ -1,0 +1,49 @@
+# cuda_akaze.cpp
+
+## 目的
+
+`cuda_akaze` は このリポジトリが同梱している外部実装を利用可能な形で保持する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_akaze.cpp`
+- 判定条件: 352 行のため sidecar 文書を維持対象にする
+- 主な定義: `AKAZEImpl`、`SphericalAKAZEImpl`、`applyScale`、`hasValidLens`、`resolveLens`、`scaleLensForImage`、`Point2f`、`downloadImage`
+- 主な依存: `opencv2/core/cuda_stream_accessor.hpp`、`opencv2/features2d.hpp`、`opencv2/imgproc.hpp`、`cuda_efficient_descriptors.h`、`spherical_projection.hpp`、`algorithm`
+
+## 現状
+
+### 主な構成
+- `AKAZEImpl` がこの module の主要な構成要素になっている
+- `SphericalAKAZEImpl` がこの module の主要な構成要素になっている
+- `applyScale` がこの module の主要な構成要素になっている
+- `hasValidLens` がこの module の主要な構成要素になっている
+- `resolveLens` がこの module の主要な構成要素になっている
+- `scaleLensForImage` がこの module の主要な構成要素になっている
+
+### 連携境界
+- `opencv2/core/cuda_stream_accessor.hpp` と連携しながら責務を完結させる
+- `opencv2/features2d.hpp` と連携しながら責務を完結させる
+- `opencv2/imgproc.hpp` と連携しながら責務を完結させる
+- `cuda_efficient_descriptors.h` と連携しながら責務を完結させる
+- `spherical_projection.hpp` と連携しながら責務を完結させる
+- `algorithm` と連携しながら責務を完結させる
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_akaze.cpp`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_akaze.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/bad.p512.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_efficient_features.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_hash_sift.md`

--- a/modules/cuda_efficient_features/src/cuda_efficient_features.cpp
+++ b/modules/cuda_efficient_features/src/cuda_efficient_features.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "cuda_efficient_features.h"
 
+#include <opencv2/cudaarithm.hpp>
 #include <opencv2/cudafilters.hpp>
 #include <opencv2/cudaimgproc.hpp>
 #include <opencv2/cudawarping.hpp>

--- a/modules/cuda_efficient_features/src/cuda_efficient_features.cpp
+++ b/modules/cuda_efficient_features/src/cuda_efficient_features.cpp
@@ -368,6 +368,41 @@ public:
 			descriptors_.download(_descriptors, stream);
 	}
 
+	void detectAndComputeAsyncPerChannel(InputArray _image, InputArray _mask,
+		std::vector<GpuMat>& keypoints, std::vector<GpuMat>& descriptors,
+		bool useProvidedKeypoints, Stream& stream) override
+	{
+		CV_Assert(_image.depth() == CV_8U);
+		CV_Assert(!useProvidedKeypoints);
+
+		if (!_mask.empty())
+		{
+			CV_Assert(_mask.type() == CV_8U);
+			CV_Assert(_mask.channels() == 1);
+		}
+
+		GpuMat image;
+		getInputMat(_image, image, stream);
+		const int channels = image.channels();
+		CV_Assert(channels >= 1);
+
+		std::vector<GpuMat> planes;
+		if (channels == 1)
+		{
+			planes.emplace_back(image);
+		}
+		else
+		{
+			planes.resize(channels);
+			cuda::split(image, planes, stream);
+		}
+
+		keypoints.resize(channels);
+		descriptors.resize(channels);
+		for (int c = 0; c < channels; ++c)
+			detectAndComputeAsync(planes[c], _mask, keypoints[c], descriptors[c], false, stream);
+	}
+
 	void convert(InputArray src, CV_OUT std::vector<KeyPoint>& dst) override
 	{
 		Mat tmp;

--- a/modules/cuda_efficient_features/src/cuda_efficient_features.md
+++ b/modules/cuda_efficient_features/src/cuda_efficient_features.md
@@ -1,0 +1,51 @@
+# cuda_efficient_features.cpp
+
+## 目的
+
+`cuda_efficient_features` は GPU feature extraction の実装を提供する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_efficient_features.cpp`
+- 判定条件: 505 行のため sidecar 文書を維持対象にする
+- 主な定義: `EfficientFeaturesImpl`、`calcKeypoints`、`radiusSuppressionBufferSize`、`radiusSuppression`、`limitPoints`、`calcResponses`、`calcAngles`、`scalePoints`
+- 主な依存: `opencv2/cudaarithm.hpp`、`opencv2/cudafilters.hpp`、`opencv2/cudaimgproc.hpp`、`opencv2/cudawarping.hpp`、`opencv2/core/cuda_stream_accessor.hpp`、`iostream`、`cuda_efficient_features.h`
+
+## 現状
+
+### 主な構成
+- `EfficientFeaturesImpl` がこの module の主要な構成要素になっている
+- `calcKeypoints` がこの module の主要な構成要素になっている
+- `radiusSuppressionBufferSize` がこの module の主要な構成要素になっている
+- `radiusSuppression` がこの module の主要な構成要素になっている
+- `limitPoints` がこの module の主要な構成要素になっている
+- `calcResponses` がこの module の主要な構成要素になっている
+
+### 連携境界
+- `opencv2/cudafilters.hpp` と連携しながら責務を完結させる
+- `opencv2/cudaarithm.hpp` と連携しながら責務を完結させる
+- `opencv2/cudaimgproc.hpp` と連携しながら責務を完結させる
+- `opencv2/cudawarping.hpp` と連携しながら責務を完結させる
+- `opencv2/core/cuda_stream_accessor.hpp` と連携しながら責務を完結させる
+- `iostream` と連携しながら責務を完結させる
+- `cuda_efficient_features.h` と連携しながら責務を完結させる
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+- OpenCV 4.10 系では multi-channel 分解に使う `cv::cuda::split()` が `cudaarithm` component へ属するため、この module も `cudaarithm` を build 依存へ含める。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_efficient_features.cpp`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_efficient_features.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/bad.p512.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_akaze.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_hash_sift.md`

--- a/modules/cuda_efficient_features/src/cuda_hash_sift.md
+++ b/modules/cuda_efficient_features/src/cuda_hash_sift.md
@@ -1,0 +1,49 @@
+# cuda_hash_sift.cpp
+
+## 目的
+
+`cuda_hash_sift` は SIFT 系 descriptor / hashing 処理を提供する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_hash_sift.cpp`
+- 判定条件: 512 行のため sidecar 文書を維持対象にする
+- 主な定義: `MatmulAndSign`、`SIFTImpl`、`SphericalSIFTImpl`、`HashSIFTImpl`、`SphericalHashSIFTImpl`、`printf`、`hashSIFTGemm`、`operator`
+- 主な依存: `opencv2/cudaarithm.hpp`、`opencv2/core/cuda_stream_accessor.hpp`、`cuda_efficient_descriptors.h`、`algorithm`、`cublas_v2.h`、`cuda_hash_sift_internal.h`
+
+## 現状
+
+### 主な構成
+- `MatmulAndSign` がこの module の主要な構成要素になっている
+- `SIFTImpl` がこの module の主要な構成要素になっている
+- `SphericalSIFTImpl` がこの module の主要な構成要素になっている
+- `HashSIFTImpl` がこの module の主要な構成要素になっている
+- `SphericalHashSIFTImpl` がこの module の主要な構成要素になっている
+- `printf` がこの module の主要な構成要素になっている
+
+### 連携境界
+- `opencv2/cudaarithm.hpp` と連携しながら責務を完結させる
+- `opencv2/core/cuda_stream_accessor.hpp` と連携しながら責務を完結させる
+- `cuda_efficient_descriptors.h` と連携しながら責務を完結させる
+- `algorithm` と連携しながら責務を完結させる
+- `cublas_v2.h` と連携しながら責務を完結させる
+- `cuda_hash_sift_internal.h` と連携しながら責務を完結させる
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_hash_sift.cpp`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_hash_sift.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/bad.p512.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_akaze.md`
+- `slam-core/3rd/cuda-efficient-features/modules/cuda_efficient_features/src/cuda_efficient_features.md`

--- a/modules/cuda_efficient_features/src/cuda_macro.h
+++ b/modules/cuda_efficient_features/src/cuda_macro.h
@@ -22,8 +22,14 @@ limitations under the License.
 
 #define CUDA_CHECK(err) \
 do {\
-	if (err != cudaSuccess) { \
-		printf("[CUDA Error] %s (code: %d) at %s:%d\n", cudaGetErrorString(err), err, __FILE__, __LINE__); \
+	const cudaError_t cuda_check_status__ = (err); \
+	if (cuda_check_status__ != cudaSuccess) { \
+		printf( \
+			"[CUDA Error] %s (code: %d) at %s:%d\n", \
+			cudaGetErrorString(cuda_check_status__), \
+			(int)(cuda_check_status__), \
+			__FILE__, \
+			__LINE__); \
 	} \
 } while (0)
 

--- a/modules/efficient_features/include/efficient_descriptors.h
+++ b/modules/efficient_features/include/efficient_descriptors.h
@@ -35,6 +35,19 @@ struct SphericalLensParams
 };
 
 /**
+ * @brief Detects keypoints and computes descriptors per channel for multi-channel input.
+ * @param feature Feature2D implementation used for detectAndCompute.
+ * @param image Input image (single or multi-channel).
+ * @param mask Optional mask for keypoint detection (single-channel 8-bit).
+ * @param keypoints Output keypoints per channel.
+ * @param descriptors Output descriptors per channel.
+ * @param useProvidedKeypoints If true, provided keypoints are used as input.
+ */
+CV_EXPORTS_W void detectAndComputePerChannel(const Ptr<Feature2D>& feature, InputArray image, InputArray mask,
+        std::vector<std::vector<KeyPoint>>& keypoints, std::vector<Mat>& descriptors,
+        bool useProvidedKeypoints = false);
+
+/**
  * Implementation of the Box Average Difference (BAD) descriptor. The method uses features
  * computed from the difference of the average gray values of two boxes in the patch.
  *

--- a/modules/efficient_features/src/bad.md
+++ b/modules/efficient_features/src/bad.md
@@ -1,0 +1,48 @@
+# bad.cpp
+
+## 目的
+
+`bad` は BAD descriptor 系の feature 計算を提供する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.cpp`
+- 判定条件: 557 行のため sidecar 文書を維持対象にする
+- 主な定義: `BoxPairParams`、`BAD_Impl`、`SphericalBAD_Impl`、`hasValidLens`、`resolveLens`、`scaleLensForImage`、`Point2f`、`computeBAD`
+- 主な依存: `opencv2/imgproc.hpp`、`efficient_descriptors.h`、`spherical_projection.hpp`、`algorithm`、`cmath`、`bad.p512.h`
+
+## 現状
+
+### 主な構成
+- `BoxPairParams` がこの module の主要な構成要素になっている
+- `BAD_Impl` がこの module の主要な構成要素になっている
+- `SphericalBAD_Impl` がこの module の主要な構成要素になっている
+- `hasValidLens` がこの module の主要な構成要素になっている
+- `resolveLens` がこの module の主要な構成要素になっている
+- `scaleLensForImage` がこの module の主要な構成要素になっている
+
+### 連携境界
+- `opencv2/imgproc.hpp` と連携しながら責務を完結させる
+- `efficient_descriptors.h` と連携しながら責務を完結させる
+- `spherical_projection.hpp` と連携しながら責務を完結させる
+- `algorithm` と連携しながら責務を完結させる
+- `cmath` と連携しながら責務を完結させる
+- `bad.p512.h` と連携しながら責務を完結させる
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.cpp`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.md`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.p512.md`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/hash_sift.md`

--- a/modules/efficient_features/src/bad.p512.md
+++ b/modules/efficient_features/src/bad.p512.md
@@ -1,0 +1,36 @@
+# bad.p512.h
+
+## 目的
+
+`bad.p512` は BAD descriptor 系の feature 計算を提供する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.p512.h`
+- 判定条件: 394 行のため sidecar 文書を維持対象にする
+
+## 現状
+
+### 主な構成
+- file 内の処理量が大きいため、隣接 module との境界を追える補助資料として扱う
+
+### 連携境界
+- 同一 package 内の class / utility と連携して役割を分担する
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.p512.h`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.p512.md`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.md`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/hash_sift.md`

--- a/modules/efficient_features/src/efficient_feature_utils.cpp
+++ b/modules/efficient_features/src/efficient_feature_utils.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 TriOrb Inc.
+
+The major design pattern of this plugin was abstracted
+from Fixstars Corporation, which is subject to the same license.
+Here is the original copyright notice:
+
+Copyright 2023 Fixstars Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http ://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "efficient_descriptors.h"
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+
+namespace cv
+{
+
+void detectAndComputePerChannel(const Ptr<Feature2D>& feature, InputArray image, InputArray mask,
+        std::vector<std::vector<KeyPoint>>& keypoints, std::vector<Mat>& descriptors,
+        bool useProvidedKeypoints)
+{
+        CV_Assert(feature);
+        CV_Assert(image.depth() == CV_8U);
+
+        if (!mask.empty())
+        {
+                CV_Assert(mask.type() == CV_8U);
+                CV_Assert(mask.channels() == 1);
+        }
+
+        const Mat imageMat = image.getMat();
+        const int channels = imageMat.channels();
+        CV_Assert(channels >= 1);
+
+        std::vector<Mat> planes;
+        if (channels == 1)
+        {
+                planes.emplace_back(imageMat);
+        }
+        else
+        {
+                split(imageMat, planes);
+        }
+
+        if (useProvidedKeypoints)
+                CV_Assert(static_cast<int>(keypoints.size()) == channels);
+
+        keypoints.resize(channels);
+        descriptors.resize(channels);
+
+        for (int c = 0; c < channels; ++c)
+                feature->detectAndCompute(planes[c], mask, keypoints[c], descriptors[c], useProvidedKeypoints);
+}
+
+} // namespace cv

--- a/modules/efficient_features/src/hash_sift.md
+++ b/modules/efficient_features/src/hash_sift.md
@@ -1,0 +1,48 @@
+# hash_sift.cpp
+
+## 目的
+
+`hash_sift` は SIFT 系 descriptor / hashing 処理を提供する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/hash_sift.cpp`
+- 判定条件: 588 行のため sidecar 文書を維持対象にする
+- 主な定義: `HistBin`、`HashSIFTImpl`、`SphericalHashSIFTImpl`、`hasValidLens`、`resolveLens`、`scaleLensForImage`、`Point2f`、`convertToGray`
+- 主な依存: `opencv2/imgproc.hpp`、`efficient_descriptors.h`、`spherical_projection.hpp`、`algorithm`、`cmath`、`hash_sift.p512.h`
+
+## 現状
+
+### 主な構成
+- `HistBin` がこの module の主要な構成要素になっている
+- `HashSIFTImpl` がこの module の主要な構成要素になっている
+- `SphericalHashSIFTImpl` がこの module の主要な構成要素になっている
+- `hasValidLens` がこの module の主要な構成要素になっている
+- `resolveLens` がこの module の主要な構成要素になっている
+- `scaleLensForImage` がこの module の主要な構成要素になっている
+
+### 連携境界
+- `opencv2/imgproc.hpp` と連携しながら責務を完結させる
+- `efficient_descriptors.h` と連携しながら責務を完結させる
+- `spherical_projection.hpp` と連携しながら責務を完結させる
+- `algorithm` と連携しながら責務を完結させる
+- `cmath` と連携しながら責務を完結させる
+- `hash_sift.p512.h` と連携しながら責務を完結させる
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/hash_sift.cpp`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/hash_sift.md`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.md`
+- `slam-core/3rd/cuda-efficient-features/modules/efficient_features/src/bad.p512.md`

--- a/samples/sample_feature_matching.md
+++ b/samples/sample_feature_matching.md
@@ -1,0 +1,46 @@
+# sample_feature_matching.cpp
+
+## 目的
+
+`sample_feature_matching` は このリポジトリが同梱している外部実装を利用可能な形で保持する module です。同梱コードまたは参照実装の役割を、このリポジトリの文脈で素早く把握できるようにします。
+
+## 対象範囲
+
+- 対象 source: `slam-core/3rd/cuda-efficient-features/samples/sample_feature_matching.cpp`
+- 判定条件: 580 行のため sidecar 文書を維持対象にする
+- 主な定義: `Dataset`、`findInputRoot`、`resolveDatasets`、`findResultsPath`、`updateResults`、`ifs`、`ensureTrailingBlank`、`ofs`
+- 主な依存: `opencv2/calib3d.hpp`、`opencv2/core.hpp`、`opencv2/imgproc.hpp`、`opencv2/highgui.hpp`、`algorithm`、`array`
+
+## 現状
+
+### 主な構成
+- `Dataset` がこの module の主要な構成要素になっている
+- `findInputRoot` がこの module の主要な構成要素になっている
+- `resolveDatasets` がこの module の主要な構成要素になっている
+- `findResultsPath` がこの module の主要な構成要素になっている
+- `updateResults` がこの module の主要な構成要素になっている
+- `ifs` がこの module の主要な構成要素になっている
+
+### 連携境界
+- `opencv2/calib3d.hpp` と連携しながら責務を完結させる
+- `opencv2/core.hpp` と連携しながら責務を完結させる
+- `opencv2/imgproc.hpp` と連携しながら責務を完結させる
+- `opencv2/highgui.hpp` と連携しながら責務を完結させる
+- `algorithm` と連携しながら責務を完結させる
+- `array` と連携しながら責務を完結させる
+
+## 実装上の判断
+
+- 同梱コードは upstream や参照実装としての責務を尊重し、この文書ではこのリポジトリから見た役割に絞って説明する。
+- project 固有の判断は wrapper や利用側へ寄せ、この file 自体の変更理由を追いやすくする。
+- 長大 file でも source 本体は read-only 前提で扱い、補足説明は sidecar 文書へ追加する。
+
+## 目標
+
+- upstream 更新や参照比較時に、この file を導入している理由と利用位置を短時間で確認できる状態を保つ。
+- project 側の差分が必要になった場合でも、変更理由を wrapper 側文書と合わせて追えるようにする。
+
+## 関連
+
+- `slam-core/3rd/cuda-efficient-features/samples/sample_feature_matching.cpp`
+- `slam-core/3rd/cuda-efficient-features/samples/sample_feature_matching.md`


### PR DESCRIPTION
## 概要
- `CUDA_CHECK(err)` が `err` を複数回評価していたため、実際の CUDA error code が log に残らないケースを修正
- `cudaErrorNoKernelImageForDevice` など Jetson / ARM 環境での実 error code を追えるようにした

## 変更内容
- `modules/cuda_efficient_features/src/cuda_macro.h`
- `CUDA_CHECK(err)` の評価結果を一度ローカル変数へ保持してから log 出力するよう変更

## 確認
- 親 repo の Jetson smoke test で `cuda_fast.cu` の実 error code `209` を確認できることを利用して切り分け
- 誤って `code: 0` が出る経路が解消されることを確認